### PR TITLE
Added an EnvelopeBasedNameResolver for Messages

### DIFF
--- a/src/Name/EnvelopeBasedNameResolver.php
+++ b/src/Name/EnvelopeBasedNameResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @license https://github.com/simple-es/message-bus-bridge/blob/master/LICENSE MIT
+ */
+
+namespace SimpleES\MessageBusBridge\Name;
+
+use SimpleBus\Message\Message;
+use SimpleBus\Message\Name\Exception\CouldNotResolveMessageName;
+use SimpleBus\Message\Name\MessageNameResolver;
+use SimpleES\EventSourcing\Event\Stream\EnvelopsEvent;
+
+/**
+ * @copyright Copyright (c) 2015 Future500 B.V.
+ * @author    Ramon de la Fuente <ramon@future500.nl>
+ */
+class EnvelopeBasedNameResolver implements MessageNameResolver
+{
+    /**
+     * The message name is taken directly from the Envelope
+     *
+     * {@inheritdoc}
+     */
+    public function resolve(Message $envelope)
+    {
+        if (!($envelope instanceof EnvelopsEvent)) {
+            throw CouldNotResolveMessageName::forMessage($envelope, 'Message should be an instance of EnvelopsEvent');
+        }
+
+        return $envelope->eventName();
+    }
+}

--- a/tests/Core/EnvelopeBasedNameResolverTest.php
+++ b/tests/Core/EnvelopeBasedNameResolverTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @license https://github.com/simple-es/message-bus-bridge/blob/master/LICENSE MIT
+ */
+
+namespace SimpleES\MessageBusBridge\Test\Core;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use SimpleES\EventSourcing\Event\Stream\EventId;
+use SimpleES\MessageBusBridge\Event\Stream\EventEnvelope;
+use SimpleES\MessageBusBridge\Name\EnvelopeBasedNameResolver;
+use SimpleES\MessageBusBridge\Test\Auxiliary\AggregateId;
+
+/**
+ * @copyright Copyright (c) 2015 Future500 B.V.
+ * @author    Ramon de la Fuente <ramon@future500.nl>
+ */
+class EnvelopeBasedNameResolverTest extends MockeryTestCase
+{
+    /**
+     * @var EventEnvelope
+     */
+    private $envelope;
+
+    /**
+     * @var \Mockery\MockInterface
+     */
+    private $event;
+
+    public function setUp()
+    {
+        $aggregateId = AggregateId::fromString('some-id');
+        $eventId     = EventId::fromString('some-id');
+
+        $this->event = \Mockery::mock('SimpleES\EventSourcing\Event\DomainEvent');
+
+        $this->envelope = EventEnvelope::envelop(
+            $eventId,
+            'some_name',
+            $this->event,
+            $aggregateId,
+            123
+        );
+    }
+
+    public function tearDown()
+    {
+        $this->envelope = null;
+        $this->event    = null;
+    }
+
+    /**
+     * @test
+     */
+    public function itReturnsTheEventNameAsTheUniqueNameOfAMessage()
+    {
+        $resolver = new EnvelopeBasedNameResolver();
+        $message = $this->envelope;
+        $this->assertSame(
+            'some_name',
+            $resolver->resolve($message)
+        );
+    }
+
+    /**
+     * @test
+     * @expectedException \SimpleBus\Message\Name\Exception\CouldNotResolveMessageName
+     */
+    public function itThrowsAnExceptionWhenGivenMessagesNotImplementingEnvelope()
+    {
+        $resolver = new EnvelopeBasedNameResolver();
+        $message = \Mockery::mock('\SimpleBus\Message\Message');
+        $resolver->resolve($message);
+    }
+
+}
+


### PR DESCRIPTION
This pull request adds a NameResolver that can be used in MessageBus's NameBasedMessageSubscriberResolver:

```
$subscriberResolver = new NameBasedMessageSubscriberResolver(
    new EnvelopeBasedNameResolver(),
    ...subscriberCollection...
);
```

The name is taken from the Envelope:

```
public function resolve(Message $envelope)
{
    ....
    return $envelope->eventName();
}
```
